### PR TITLE
font fix

### DIFF
--- a/Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.cpp
@@ -98,14 +98,21 @@ void SetSpriteFont(int fontNum, int sprite, int rows, int columns, int charWidth
 	engine->PrintDebugConsole("AGSSpriteFont: SetSpriteFont");
 	fontRenderer->SetSpriteFont(fontNum, sprite, rows, columns, charWidth, charHeight, charMin, charMax, use32bit);
 	engine->ReplaceFontRenderer(fontNum, fontRenderer);
-
 }
 
 void SetVariableSpriteFont(int fontNum, int sprite)
 {
-	engine->PrintDebugConsole("AGSSpriteFont: SetVariableFont");
-	vWidthRenderer->SetSprite(fontNum, sprite);
-	engine->ReplaceFontRenderer(fontNum, vWidthRenderer);
+    //in kathy rain, font 13 == fridge and font 16 is postcard.
+    //The postcard overflows if the rest of the plugin is missing
+    //'dynamic line height modification' code. But it's not needed,
+    //just blacklist that font and fallback to default. It's *only*
+    //used on the postcard afaict.
+    if (fontNum == 16 && sprite == 2630) {
+        return;
+    }
+    engine->PrintDebugConsole("AGSSpriteFont: SetVariableFont");
+    vWidthRenderer->SetSprite(fontNum, sprite);
+    engine->ReplaceFontRenderer(fontNum, vWidthRenderer);
 }
 
 void SetGlyph(int fontNum, int charNum, int x, int y, int width, int height)
@@ -137,6 +144,7 @@ const char *ourScriptHeader =
   "import void SetVariableSpriteFont(int fontNum, int sprite);\r\n"
   "import void SetGlyph(int fontNum, int charNum, int x, int y, int width, int height);\r\n"
   "import void SetSpacing(int fontNum, int spacing);\r\n"
+  "import void SetLineHeightAdjust(int fontNum, int LineHeight, int SpacingHeight, int SpacingOverride);\r\n"
   ;
 
 //------------------------------------------------------------------------------
@@ -245,6 +253,8 @@ void AGS_EngineShutdown()
 	// Called by the game engine just before it exits.
 	// This gives you a chance to free any memory and do any cleanup
 	// that you need to do before the engine shuts down.
+	delete fontRenderer;
+	delete vWidthRenderer;
 }
 
 //------------------------------------------------------------------------------

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthFont.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthFont.cpp
@@ -6,10 +6,20 @@ VariableWidthFont::VariableWidthFont(void)
 	Spacing = 0;
 	FontReplaced = 0;
 	SpriteNumber = 0;
+	LineHeightAdjust = 0;
+	LineSpacingAdjust = 0;
+	LineSpacingOverride = 0;
 }
 
 
 VariableWidthFont::~VariableWidthFont(void) = default;
+
+void VariableWidthFont::SetLineHeightAdjust(int LineHeight, int SpacingHeight, int SpacingOverride)
+{
+	LineHeightAdjust = LineHeight;
+	LineSpacingAdjust = SpacingHeight;
+	LineSpacingOverride = SpacingOverride;
+}
 
 void VariableWidthFont::SetGlyph(int character, int x, int y, int width, int height)
 {

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthFont.h
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthFont.h
@@ -8,10 +8,13 @@ public:
 	VariableWidthFont(void);
 	~VariableWidthFont(void);
 	void SetGlyph(int character, int x, int y, int width, int height);
+	void SetLineHeightAdjust(int LineHeight, int SpacingHeight, int SpacingOverride);
 	int SpriteNumber;
 	int FontReplaced;
 	int Spacing;
-	int LineHeightAdjust1, LineHeightAdjust2, LineHeightAdjust3;
+	int LineHeightAdjust;
+	int LineSpacingAdjust;
+	int LineSpacingOverride;
 	std::map<char, CharacterEntry> characters;
 
 private:

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.cpp
@@ -83,12 +83,12 @@ void VariableWidthSpriteFontRenderer::SetSprite(int fontNum, int spriteNum)
 	font->SpriteNumber = spriteNum;
 }
 
-void VariableWidthSpriteFontRenderer::SetLineHeightAdjust(int fontNum, int arg1, int arg2, int arg3)
+void VariableWidthSpriteFontRenderer::SetLineHeightAdjust(int fontNum, int LineHeight, int SpacingHeight, int SpacingOverride)
 {
 	VariableWidthFont *font = getFontFor(fontNum);
-	font->LineHeightAdjust1 = arg1;
-	font->LineHeightAdjust2 = arg2;
-	font->LineHeightAdjust3 = arg3;
+	font->LineHeightAdjust = LineHeight;
+	font->LineSpacingAdjust = SpacingHeight;
+	font->LineSpacingOverride = SpacingOverride;
 }
 
 VariableWidthFont *VariableWidthSpriteFontRenderer::getFontFor(int fontNum){
@@ -114,7 +114,7 @@ void VariableWidthSpriteFontRenderer::RenderText(const char *text, int fontNumbe
 		char c = text[i];
 				
 		BITMAP *src = _engine->GetSpriteGraphic(font->SpriteNumber);
-		Draw(src, destination, x + totalWidth, y, font->characters[c].X, font->characters[c].Y, font->characters[c].Width, font->characters[c].Height); 
+		Draw(src, destination, x + totalWidth, y, font->characters[c].X, font->characters[c].Y, font->characters[c].Width, font->characters[c].Height, colour);
 		totalWidth += font->characters[c].Width;
 		if (text[i] != ' ') totalWidth += font->Spacing;
 	}
@@ -122,7 +122,7 @@ void VariableWidthSpriteFontRenderer::RenderText(const char *text, int fontNumbe
 }
 
 
-void VariableWidthSpriteFontRenderer::Draw(BITMAP *src, BITMAP *dest, int destx, int desty, int srcx, int srcy, int width, int height)
+void VariableWidthSpriteFontRenderer::Draw(BITMAP *src, BITMAP *dest, int destx, int desty, int srcx, int srcy, int width, int height, int colour)
 {
 
 	int srcWidth, srcHeight, destWidth, destHeight, srcColDepth, destColDepth;
@@ -149,7 +149,11 @@ void VariableWidthSpriteFontRenderer::Draw(BITMAP *src, BITMAP *dest, int destx,
 	int starty = MAX(0, (-1 * desty));
 
 	
-	int srca, srcr, srcg, srcb, desta, destr, destg, destb, finalr, finalg, finalb, finala, col;
+	int srca, srcr, srcg, srcb, desta, destr, destg, destb, finalr, finalg, finalb, finala, col, col_r, col_g, col_b;
+
+	col_r = getr32(colour);
+	col_g = getg32(colour);
+	col_b = getb32(colour);
 
 	for(int x = startx; x < width; x ++)
 	{
@@ -186,9 +190,9 @@ void VariableWidthSpriteFontRenderer::Draw(BITMAP *src, BITMAP *dest, int destx,
 						desta =  geta32(destlongbuffer[destyy][destxx]);
                 
 
-						finalr = srcr;
-						finalg = srcg;
-						finalb = srcb;   
+						finalr = (col_r * srcr) / 255;
+						finalg = (col_g * srcg) / 255;
+						finalb = (col_b * srcb) / 255;
               
                                                                
 						finala = 255-(255-srca)*(255-desta)/255;                                              

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.h
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.h
@@ -19,12 +19,12 @@ public:
 	void SetGlyph(int fontNum, int charNum, int x, int y, int width, int height);
 	void SetSprite(int fontNum, int spriteNum);
 	void SetSpacing(int fontNum, int spacing);
-	void SetLineHeightAdjust(int fontNum, int arg1, int arg2, int arg3);
+	void SetLineHeightAdjust(int fontNum, int LineHeight, int SpacingHeight, int SpacingOverride);
 
 private:
 	IAGSEngine *_engine;
 	std::vector<VariableWidthFont * > _fonts;
 	VariableWidthFont *getFontFor(int fontNum);
-	void Draw(BITMAP *src, BITMAP *dest, int destx, int desty, int srcx, int srcy, int width, int height);
+	void Draw(BITMAP *src, BITMAP *dest, int destx, int desty, int srcx, int srcy, int width, int height, int colour);
 };
 


### PR DESCRIPTION
This makes the game boot with the font 'ok-ish' here.

I expect occasional defects because i *didn't* put in this hack that actually uses the new line spacing stuff:
https://github.com/josthas/KrusAGS/blob/master/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.cpp#L38

This is purely for the font not to look like ass because the trick they use to make color shadow appears to be to paint it twice.

Apparently both Kathy Rain and Whispers of a machine don't have significant differences on this plugin, from looking at a diff of both repos on this dir.